### PR TITLE
레이아웃 UI 스타일 수정 및 헤더 부분 컴포넌트화 작업

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,10 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <div className={styles["root-container"]}>
+          <div className={styles["explain-container"]}>
+            지금 바로
+            <br /> 리필드를 검색하세요!
+          </div>
           <div className={styles["page-container"]}>
             <Header />
             <div className={styles["main-container"]}>{children}</div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
         <div className={styles["root-container"]}>
           <div className={styles["page-container"]}>
             <Header />
-            {children}
+            <div className={styles["main-container"]}>{children}</div>
           </div>
         </div>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import "normalize.css";
 
+import { Header } from "@/components/common/Header";
+import styles from "./rootLayout.module.scss";
+
 export const metadata = {
   title: "",
   description: "",
@@ -12,7 +15,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <div className={styles["root-container"]}>
+          <div className={styles["page-container"]}>
+            <Header />
+            {children}
+          </div>
+        </div>
+      </body>
     </html>
   );
 }

--- a/src/app/rootLayout.module.scss
+++ b/src/app/rootLayout.module.scss
@@ -2,10 +2,21 @@ $root-conatiner-height: 100vh;
 $page-conatiner-width: 375px;
 $root-background-color: #f2f2f2;
 $page-background-color: #fff;
+$explain-container-width: 217px;
+$explain-container-height: 72px;
+$explain-container-font-weight: 700;
+$explain-container-font-size: 25px;
+$explain-container-margin-right: 31px;
 
 @mixin flex-display($direction) {
   display: flex;
   flex-direction: $direction;
+}
+
+@mixin mobile {
+  @media (width <= 700px) {
+    @content;
+  }
 }
 
 .root-container {
@@ -26,4 +37,18 @@ $page-background-color: #fff;
       overflow-y: scroll;
     }
   }
+}
+
+.explain-container {
+  @include mobile {
+    display: none;
+  }
+
+  align-self: center;
+  width: $explain-container-width;
+  height: $explain-container-height;
+  font-weight: $explain-container-font-weight;
+  font-size: $explain-container-font-size;
+  text-align: center;
+  margin-right: $explain-container-margin-right;
 }

--- a/src/app/rootLayout.module.scss
+++ b/src/app/rootLayout.module.scss
@@ -1,0 +1,25 @@
+$root-conatiner-height: 100vh;
+$page-conatiner-width: 375px;
+$root-background-color: #f2f2f2;
+$page-background-color: #fff;
+
+@mixin flex-display($direction) {
+  display: flex;
+  flex-direction: $direction;
+  justify-content: center;
+}
+
+.root-container {
+  @include flex-display(row);
+
+  margin: auto;
+  height: $root-conatiner-height;
+  background-color: $root-background-color;
+
+  .page-container {
+    @include flex-display(column);
+
+    width: $page-conatiner-width;
+    background-color: $page-background-color;
+  }
+}

--- a/src/app/rootLayout.module.scss
+++ b/src/app/rootLayout.module.scss
@@ -6,12 +6,12 @@ $page-background-color: #fff;
 @mixin flex-display($direction) {
   display: flex;
   flex-direction: $direction;
-  justify-content: center;
 }
 
 .root-container {
   @include flex-display(row);
 
+  justify-content: center;
   margin: auto;
   height: $root-conatiner-height;
   background-color: $root-background-color;
@@ -21,5 +21,9 @@ $page-background-color: #fff;
 
     width: $page-conatiner-width;
     background-color: $page-background-color;
+
+    .main-container {
+      overflow-y: scroll;
+    }
   }
 }

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,24 +1,14 @@
 import styles from "./shop.module.scss";
-import Image from "next/image";
-import menuIcon from "../../../public/icon/menu.svg";
-import cartIcon from "../../../public/icon/cart.svg";
 import { ProductItem } from "@/components/shop/product/ProductItem";
 import { shopRepository } from "@/data/repository/shopRepository";
+import { Header } from "@/components/common/Header";
 
 export default async function Shop() {
   const productList = await shopRepository.getShopProductList();
 
   return (
     <div className={styles["page-container"]}>
-      <header className={styles["header-container"]}>
-        <div className={styles["menu-box"]}>
-          <Image src={menuIcon} alt="menu" />
-        </div>
-        <div className={styles["title-box"]}>Refilled</div>
-        <div className={styles["cart-box"]}>
-          <Image src={cartIcon} alt="cart" />
-        </div>
-      </header>
+      <Header />
       <main className={styles["main-container"]}>
         <div className={styles["content-box"]}>
           <p>사이토카인.</p>

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,37 +1,33 @@
 import styles from "./shop.module.scss";
 import { ProductItem } from "@/components/shop/product/ProductItem";
 import { shopRepository } from "@/data/repository/shopRepository";
-import { Header } from "@/components/common/Header";
 
 export default async function Shop() {
   const productList = await shopRepository.getShopProductList();
 
   return (
-    <div className={styles["page-container"]}>
-      <Header />
-      <main className={styles["main-container"]}>
-        <div className={styles["content-box"]}>
-          <p>사이토카인.</p>
-          <p>완벅한 탈모케어를 위한 선택</p>
-        </div>
-        <section className={styles["product-box"]}>
-          {productList.map((item) => {
-            return (
-              <ProductItem
-                key={item.id}
-                name={item.name}
-                description={item.description}
-                originPrice={item.originPrice}
-                price={item.price}
-                discountPercent={item.discountPercent}
-                tagInfo={item.tagInfo}
-                imageUrl={item.imageUrl}
-                productOptions={item.productOptions}
-              />
-            );
-          })}
-        </section>
-      </main>
-    </div>
+    <main className={styles["main-container"]}>
+      <div className={styles["content-box"]}>
+        <p>사이토카인.</p>
+        <p>완벅한 탈모케어를 위한 선택</p>
+      </div>
+      <section className={styles["product-box"]}>
+        {productList.map((item) => {
+          return (
+            <ProductItem
+              key={item.id}
+              name={item.name}
+              description={item.description}
+              originPrice={item.originPrice}
+              price={item.price}
+              discountPercent={item.discountPercent}
+              tagInfo={item.tagInfo}
+              imageUrl={item.imageUrl}
+              productOptions={item.productOptions}
+            />
+          );
+        })}
+      </section>
+    </main>
   );
 }

--- a/src/app/shop/shop.module.scss
+++ b/src/app/shop/shop.module.scss
@@ -23,7 +23,6 @@ $content-line-height: 30px;
 
   height: 100%;
   padding: $main-padding;
-  overflow-y: scroll;
 
   .content-box {
     @include content-font-settings;

--- a/src/app/shop/shop.module.scss
+++ b/src/app/shop/shop.module.scss
@@ -1,43 +1,46 @@
-.shop-container {
+$main-padding: 0 16px;
+$product-grid-gap: 32px 7px;
+$white: #fff;
+$content-margin: 26px 0;
+$content-font-size: 20px;
+$content-font-weight: 600;
+$content-line-height: 30px;
+
+@mixin flex-display($direction) {
   display: flex;
-  flex-direction: row;
+  flex-direction: $direction;
   justify-content: center;
-  margin: auto;
-  height: 100vh;
-  background-color: #f2f2f2;
 }
 
-.page-container {
-  display: flex;
-  flex-direction: column;
-  width: 375px;
-  background-color: #fff;
+@mixin content-font-settings {
+  font-size: $content-font-size;
+  font-weight: $content-font-weight;
+  line-height: $content-line-height;
+}
 
-  .main-container {
-    display: flex;
-    flex-direction: column;
+.main-container {
+  @include flex-display(column);
+
+  height: 100%;
+  padding: $main-padding;
+  overflow-y: scroll;
+
+  .content-box {
+    @include content-font-settings;
+
+    margin: $content-margin;
+
+    p {
+      margin: 0;
+      background-color: $white;
+    }
+  }
+
+  .product-box {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: $product-grid-gap;
+    align-content: start;
     height: 100%;
-    padding: 0 16px;
-    overflow-y: scroll;
-
-    .content-box {
-      margin: 26px 0;
-      font-size: 20px;
-      font-weight: 600px;
-      line-height: 30px;
-
-      p {
-        margin: 0;
-        background-color: white;
-      }
-    }
-
-    .product-box {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 32px 7px;
-      align-content: start;
-      height: 100%;
-    }
   }
 }

--- a/src/app/shop/shop.module.scss
+++ b/src/app/shop/shop.module.scss
@@ -13,39 +13,6 @@
   width: 375px;
   background-color: #fff;
 
-  .header-container {
-    display: flex;
-    height: 60px;
-    background-color: #fff9;
-    border-top: 1px solid #000;
-    border-bottom: 1px solid #000;
-
-    .menu-box {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 60px;
-    }
-
-    .title-box {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 255px;
-      border-left: 1px solid #000;
-      border-right: 1px solid #000;
-      color: #040000;
-      font-size: 25px;
-    }
-
-    .cart-box {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 60px;
-    }
-  }
-
   .main-container {
     display: flex;
     flex-direction: column;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,20 @@
+import styles from "./header.module.scss";
+
+import Image from "next/image";
+import menuIcon from "../../../public/icon/menu.svg";
+import cartIcon from "../../../public/icon/cart.svg";
+import Link from "next/link";
+
+export function Header() {
+  return (
+    <header className={styles["header-container"]}>
+      <Link className={styles["menu-box"]} href="/shop">
+        <Image src={menuIcon} alt="menu" />
+      </Link>
+      <div className={styles["title-box"]}>Refilled</div>
+      <Link className={styles["cart-box"]} href="/cart">
+        <Image src={cartIcon} alt="cart" />
+      </Link>
+    </header>
+  );
+}

--- a/src/components/common/header.module.scss
+++ b/src/components/common/header.module.scss
@@ -1,0 +1,43 @@
+$container-min-height: 60px;
+$box-width: 60px;
+$title-box-width: 255px;
+$title-font-size: 25px;
+$white-transparent: #fff9;
+$black: #000;
+$title-color: #040000;
+
+@mixin flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header-container {
+  display: flex;
+  min-height: $container-min-height;
+  background-color: $white-transparent;
+  border-top: 1px solid $black;
+  border-bottom: 1px solid $black;
+
+  .menu-box {
+    @include flex-center;
+
+    width: $box-width;
+  }
+
+  .title-box {
+    @include flex-center;
+
+    width: $title-box-width;
+    border-left: 1px solid $black;
+    border-right: 1px solid $black;
+    color: $title-color;
+    font-size: $title-font-size;
+  }
+
+  .cart-box {
+    @include flex-center;
+
+    width: $box-width;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * 현재 프로젝트에서 메인 페이지가 /shop 이므로
+ * 해당 /shop 경로로 redirect 설정을 하였습니다.
+ */
+export function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL("/shop", request.url));
+}
+
+export const config = {
+  matcher: "/",
+};


### PR DESCRIPTION
## PR 배경  

 - 헤더 부분 컴포넌트화 작업을 진행하였고, 이로 인해 레이아웃 스타일 부분에 변경이 생겨 해당 부분 수정하였습니다.
   - /cart 페이지에도 헤더 영역이 필요하므로 최상위 레이이웃에 해당 헤더 부분을 적용하였습니다. 
 - 현재 프로젝트에는 "/" 경로에 페이지가 존재하지 않으므로 인해 "/" -> "/shop" 으로 redirect 설정을 하였습니다. 
 - 브라우저 크기에 따라 설명문구를 적용하였습니다. (스크린샷 참조 부탁드립니다.)



## 작업한 내용

 - 경로 redirect 작업 ("/" -> "/shop")
 - 헤더 영역 컴포넌트화 작업
 - 전반적인 스타일 수정 (레이아웃 관련 부분)
 - 브라우저 크기에 따라 설명 문구 적용 및 스타일 적용



## 스크린샷

 - 브라우저 크기에 따라 설명 문구 적용
  
<img width="694" alt="스크린샷 2023-05-31 오후 5 05 48" src="https://github.com/KongWooJeong/refilled/assets/44581631/6d1fb080-b3ab-419a-b1af-eeae2ec03a04">
<img width="467" alt="스크린샷 2023-05-31 오후 5 06 02" src="https://github.com/KongWooJeong/refilled/assets/44581631/9fbd67a6-5d95-4cea-b14f-a2461bdb3e7f">



