### PR TITLE
shop 페이지 대한 에러 컴포넌트 생성 및 적용 작업

### DIFF
--- a/src/app/shop/error.tsx
+++ b/src/app/shop/error.tsx
@@ -15,10 +15,14 @@ export default function Error({
     console.error(error);
   }, [error]);
 
+  function handleRetryButtonClick() {
+    reset();
+  }
+
   return (
     <div className={styles["error-container"]}>
       <h2>문제가 발생하였습니다.</h2>
-      <button onClick={() => reset()}>Try again</button>
+      <button onClick={handleRetryButtonClick}>Try again</button>
     </div>
   );
 }

--- a/src/app/shop/error.tsx
+++ b/src/app/shop/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import styles from "./shop.module.scss";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // 에러 로그 확인용 입니다.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles["error-container"]}>
+      <h2>문제가 발생하였습니다.</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/src/app/shop/layout.tsx
+++ b/src/app/shop/layout.tsx
@@ -3,13 +3,5 @@ export default function ShopLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div>
-      {/* 
-        하위 컴포넌트에서 외부 api를 통해 데이터를 가져오기 때문에 
-        해당 부분 ErrorBoundary 추가할 예정입니다.
-      */}
-      {children}
-    </div>
-  );
+  return <div>{children}</div>;
 }

--- a/src/app/shop/shop.module.scss
+++ b/src/app/shop/shop.module.scss
@@ -43,3 +43,10 @@ $content-line-height: 30px;
     height: 100%;
   }
 }
+
+.error-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
## PR 배경  

 - shop 페이지에서 서버를 통해 상품데이터를 가져오므로 해당 과정에서 에러가 발생할 수 있으몰 해당 에러발생했을때 노출되는 화면을 생성하는 작업입니다.
 - 별도의 ErrorBoundary 를 적용하지 않는 이유는 nextjs 에서 App 라우터 방식일때 해당 하위 폴더구조에 error.tsx 컴포넌트를 생성하면 nextjs 에서 자동으로 ErrorBoundary 가 적용되어서 입니다.
  - 해당 내용에 대해 공식문서 링크입니다
  -  https://nextjs.org/docs/app/building-your-application/routing/error-handling#how-errorjs-works



## 작업한 내용

 - 에러페이지 생성




## 스크린샷
<img width="749" alt="스크린샷 2023-06-01 오후 12 41 29" src="https://github.com/KongWooJeong/refilled/assets/44581631/eb0d1b36-e3e1-4970-9036-672556b24c75">





