### PR TITLE
shop 페이지에 대하여 로딩 페이지 생성 및 스타일 수정

### DIFF
--- a/src/app/shop/loading.tsx
+++ b/src/app/shop/loading.tsx
@@ -1,0 +1,9 @@
+import styles from "./shop.module.scss";
+
+export default function Loading() {
+  return (
+    <div className={styles["loading-container"]}>
+      데이터를 가져오는 중입니다.
+    </div>
+  );
+}

--- a/src/app/shop/shop.module.scss
+++ b/src/app/shop/shop.module.scss
@@ -18,6 +18,12 @@ $content-line-height: 30px;
   line-height: $content-line-height;
 }
 
+%box-style {
+  @include flex-display(column);
+
+  align-items: center;
+}
+
 .main-container {
   @include flex-display(column);
 
@@ -45,8 +51,9 @@ $content-line-height: 30px;
 }
 
 .error-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  @extend %box-style;
+}
+
+.loading-container {
+  @extend %box-style;
 }


### PR DESCRIPTION
## PR 배경  

 - shop 페이지에서 서버에서 데이터를 가져올때 오랜시간이 걸리수 있으므로 해당 상황일때 유저에게 로딩 페이지를 보여주기 위한 작업입니다.
 - Suspense 컴포넌트를 적용하지 않는 이유는 nextjs 에서 loading.tsx 파일을 생성하여 적용하면 자동으로 적용되기 때문입니다.
 - 해당 내용관련하여 공식문서 링크 입니다.
 - https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming#instant-loading-states



## 작업한 내용

 - 로딩 컴포넌트 생성 후 적용




## 스크린샷


<img width="694" alt="스크린샷 2023-06-01 오후 1 16 10" src="https://github.com/KongWooJeong/refilled/assets/44581631/0d19823a-9b0a-4be0-bbb9-fb607d606a99">


